### PR TITLE
use default ordering for search reset

### DIFF
--- a/portal/src/components/Search.component.vue
+++ b/portal/src/components/Search.component.vue
@@ -254,6 +254,7 @@ export default {
         {value: 'asc', label: 'Ascending'},
         {value: 'desc', label: 'Descending'}
       ],
+      defaultOrder: this.$store.state.configuration.ui.search?.defaultOrder || {value: 'asc', label: 'Ascending'},
       selectedOrder: this.$store.state.configuration.ui.search?.defaultOrder || {value: 'asc', label: 'Ascending'},
       searchFrom: 0,
       selectedOperation: 'must',
@@ -490,7 +491,7 @@ export default {
       this.searchFields = this.$store.state.configuration.ui.searchFields;
       this.$route.query.sf = encodeURIComponent(this.searchFields);
       this.$route.query.o = this.selectedOperation;
-      this.selectedOrder = 'desc';
+      this.selectedOrder = this.defaultOrder;
       this.filterButton = [];
       this.isStart = true;
       this.isBrowse = false;

--- a/portal/src/components/Search.component.vue
+++ b/portal/src/components/Search.component.vue
@@ -491,7 +491,7 @@ export default {
       this.searchFields = this.$store.state.configuration.ui.searchFields;
       this.$route.query.sf = encodeURIComponent(this.searchFields);
       this.$route.query.o = this.selectedOperation;
-      this.selectedOrder = this.defaultOrder;
+      this.selectedOrder = this.defaultOrder.value;
       this.filterButton = [];
       this.isStart = true;
       this.isBrowse = false;
@@ -573,9 +573,6 @@ export default {
         filters = {};
       }
       let order = this.selectedOrder.value;
-      if (!order) {
-        order = this.selectedOrder;
-      }
       try {
         this.items = await this.$elasticService.multi({
           multi: this.searchInput,


### PR DESCRIPTION
Replaces the hard-coded "desc" order with config value, when search is reset.