### PR TITLE
Member dot points

### DIFF
--- a/src/components/CollectionMembers.vue
+++ b/src/components/CollectionMembers.vue
@@ -79,7 +79,7 @@ onMounted(setMembers);
             @update:page-size="pageSize" />
         </div>
         <div v-loading="isLoading">
-          <ul v-for="item of items" :key="item.id">
+          <ul v-for="item of items" :key="item.id" class="list-disc">
             <li>
               <CollectionItem :field="item" :routePath="routePath" />
             </li>


### PR DESCRIPTION
Added bullet points to list of collections

Feedback from the PARADISEC team that it's difficult to distinguish them when we have long titles that wrap lines

<img width="623" height="501" alt="image" src="https://github.com/user-attachments/assets/aa046bd7-bfd8-45d2-a08d-5ea3c0fb2857" />
